### PR TITLE
GTB-37 [feat] 현장 웨이팅 API 구현

### DIFF
--- a/src/main/java/site/gachontable/gachontablebe/domain/waiting/domain/Waiting.java
+++ b/src/main/java/site/gachontable/gachontablebe/domain/waiting/domain/Waiting.java
@@ -29,7 +29,7 @@ public class Waiting extends BaseTimeEntity {
     private Status waitingStatus;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)", nullable = false)
+    @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     private User user;
 
     @ManyToOne

--- a/src/main/java/site/gachontable/gachontablebe/domain/waiting/presentation/WaitingController.java
+++ b/src/main/java/site/gachontable/gachontablebe/domain/waiting/presentation/WaitingController.java
@@ -8,9 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import site.gachontable.gachontablebe.domain.admin.domain.Admin;
-import site.gachontable.gachontablebe.domain.admin.domain.repository.AdminRepository;
-import site.gachontable.gachontablebe.domain.admin.exception.AdminNotFoundException;
 import site.gachontable.gachontablebe.domain.user.domain.User;
 import site.gachontable.gachontablebe.domain.user.domain.repository.UserRepository;
 import site.gachontable.gachontablebe.domain.user.exception.UserNotFoundException;
@@ -28,7 +25,6 @@ public class WaitingController {
     private final CreateWaiting createWaiting;
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
-    private final AdminRepository adminRepository;
 
     @Operation(summary = "원격 웨이팅", description = "원격 웨이팅을 신규로 생성합니다.")
     @ApiResponses({
@@ -55,10 +51,7 @@ public class WaitingController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/onsite/{pubId}")
-    public ResponseEntity<WaitingResponse> createOnsite(@RequestHeader("Authorization") String authorizationHeader,
-                                                        @RequestBody OnsiteWaitingRequest request) {
-        Admin admin = adminRepository.findById(jwtProvider.getUserIdFromToken(authorizationHeader))
-                .orElseThrow(AdminNotFoundException::new);
+    public ResponseEntity<WaitingResponse> createOnsite(@RequestBody OnsiteWaitingRequest request) {
         return ResponseEntity.ok(createWaiting.execute(request));
     }
 }

--- a/src/main/java/site/gachontable/gachontablebe/domain/waiting/usecase/CreateWaitingImpl.java
+++ b/src/main/java/site/gachontable/gachontablebe/domain/waiting/usecase/CreateWaitingImpl.java
@@ -46,7 +46,11 @@ public class CreateWaitingImpl implements CreateWaiting {
         if (!pub.getOpenStatus()) {
             throw new PubNotOpenException();
         }
+        waitingRepository.save(
+                Waiting.create(Position.ONSITE, request.headCount(), Status.WAITING, null, pub));
 
+        pub.updateWaitingCount(pub.getWaitingCount() + 1);
+        pubRepository.save(pub);
         // TODO : 카카오 알림톡 전송
 
         return new WaitingResponse(true, SuccessCode.ONSITE_WAITING_SUCCESS.getMessage());


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 현장 웨이팅 로직을 구현하기 위함입니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
현장 웨이팅의 경우, 비로그인 사용자도 웨이팅 신청을 할 수 있도록 정책을 정의하였습니다.
이에 따라 웨이팅 로직 진행 중 멤버 객체의 생성 여부에 대해서 많은 고민을 하였지만, 전체적인 흐름 상 굳이 그럴 필요는 없다고 생각하였습니다.

추후 로직 진행 중 문제가 생기면 수정 예정입니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<img width="1401" alt="스크린샷 2024-07-05 오전 2 18 25" src="https://github.com/Gachon-Table/GachonTable-BE/assets/129377887/63dba0e3-7ece-407d-9e52-ed31f9fc8f14">

<img width="1604" alt="스크린샷 2024-07-05 오전 2 19 08" src="https://github.com/Gachon-Table/GachonTable-BE/assets/129377887/932484a0-1fd6-4f2c-8442-ad75fa4e36ed">

<br>

## 4. 완료 사항
- [x] 현장 웨이팅 로직 구현
<br>

## 5. 추가 사항
- 정책에 따른 웨이팅 객체의 도메인을 수정하였습니다.
- Security Authentication 방식으로 유저 인증 방식을 변경할 예정입니다.