### PR TITLE
[GTB-56] [feat] 주점 검색 API 구현

### DIFF
--- a/src/main/java/site/gachontable/gachontablebe/domain/pub/domain/repository/PubRepository.java
+++ b/src/main/java/site/gachontable/gachontablebe/domain/pub/domain/repository/PubRepository.java
@@ -12,5 +12,5 @@ public interface PubRepository extends JpaRepository<Pub, Integer> {
     Optional<Pub> findByPubId(Integer pubId);
 
     @Query("SELECT DISTINCT p FROM pub p WHERE p.pubName LIKE %:keyword% OR p.oneLiner LIKE %:keyword%")
-    List<Pub> findAllByTitleOrTextDataContaining(@Param("keyword") String keyword);
+    List<Pub> findAllByPubNameOrOneLinerContaining(@Param("keyword") String keyword);
 }

--- a/src/main/java/site/gachontable/gachontablebe/domain/pub/usecase/SearchPubImpl.java
+++ b/src/main/java/site/gachontable/gachontablebe/domain/pub/usecase/SearchPubImpl.java
@@ -15,7 +15,7 @@ public class SearchPubImpl implements SearchPub {
 
     @Override
     public List<GetPubsResponse> execute(String keyword) {
-        List<Pub> pubs = pubRepository.findAllByTitleOrTextDataContaining(keyword);
+        List<Pub> pubs = pubRepository.findAllByPubNameOrOneLinerContaining(keyword);
 
         return pubs.stream().map(GetPubsResponse::of).toList();
     }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 랜딩 페이지에서 주점 검색기능을 도입하기 위함입니다.
### `elasticSearch` 대신 `@Query`
- elasticSearch를 사용하고자 하였지만 다음과 같은 이유로 쿼리문을 통한 검색 기능을 구현하였습니다.
  1. 마감기한에 따른 시간적 한계
  2. 주점의 양이 많아야 20개 남짓이어기에 `elasticSearch`를 통한 성능에서의 이점을 사용자가 체감하기 어려움
  
 - 따라서 리포지토리 내부에서 `@Query` 메서드를 통해 직접 쿼리를 작성, 검색 로직을 구현하였습니다.
 - 이 때, 제목 및 주점 한줄 소개에 키워드가 포함되어 있으면 해당하는 주점을 반환합니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 특이사항 없습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
### 등록 주점
<img width="124" alt="스크린샷 2024-07-14 오후 2 35 21" src="https://github.com/user-attachments/assets/da9245b5-1780-4628-91aa-72d42407dab9">


### 검색 결과
<img width="1407" alt="스크린샷 2024-07-14 오후 2 35 35" src="https://github.com/user-attachments/assets/76ef558b-63a3-4b23-91eb-692a7112f5ae">


<br>

## 4. 완료 사항
- [x] 주점 검색 기능 구현
- close #55 
<br>

## 5. 추가 사항
